### PR TITLE
Add @GuildOnly Annotation

### DIFF
--- a/src/main/kotlin/dev/ruffrick/jda/commands/CommandRegistry.kt
+++ b/src/main/kotlin/dev/ruffrick/jda/commands/CommandRegistry.kt
@@ -102,6 +102,10 @@ class CommandRegistry(
                 commandData.defaultPermissions = DefaultMemberPermissions.enabledFor(*it.permissions)
             }
 
+            command::class.findAnnotation<GuildOnly>()?.let {
+                commandData.setGuildOnly(true)
+            }
+
             command.commandRegistry = this
             command.commandData = commandData
 

--- a/src/main/kotlin/dev/ruffrick/jda/commands/annotations/GuildOnly.kt
+++ b/src/main/kotlin/dev/ruffrick/jda/commands/annotations/GuildOnly.kt
@@ -1,0 +1,5 @@
+package dev.ruffrick.jda.commands.annotations
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class GuildOnly()


### PR DESCRIPTION
# Overview
This pull request introduces a new `@GuildOnly` annotation, that can be used on classes. It sets the "guildOnly" property of a command so that it can only be used when ran in guilds.

# Changes
- `@GuildOnly` annotation added.
- `CommandRegistry.kt` updated to support this new annotation.