### PR TITLE
Bump Versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
-    kotlin("jvm") version "1.8.10"
+    kotlin("jvm") version "1.9.0"
 
     `maven-publish`
 }
@@ -17,13 +17,13 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-reflect
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.10")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.0")
 
     // https://mvnrepository.com/artifact/net.dv8tion/JDA
-    compileOnly("net.dv8tion:JDA:5.0.0-beta.3")
+    compileOnly("net.dv8tion:JDA:5.0.0-beta.12")
 
     // https://github.com/ruffrick/jda-kotlinx
-    api("com.github.ruffrick:jda-kotlinx:fc536ec")
+    api("com.github.ruffrick:jda-kotlinx:9c48cfb")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     compileOnly("net.dv8tion:JDA:5.0.0-beta.12")
 
     // https://github.com/ruffrick/jda-kotlinx
-    api("com.github.ruffrick:jda-kotlinx:9c48cfb")
+    api("com.github.ruffrick:jda-kotlinx:b101ea7")
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
## Draft PR
Before this PR can be merged, [#2](https://github.com/ruffrick/jda-kotlinx/pull/2) needs to be merged, and the version must be updated in `build.gradle.kts`.

This PR bumps to the following versions:
<!-- had to make this table look nice :3 -->
| Type                      | Name       |         Version |
| :------------------------ | :--------- | --------------: |
| `kotlin.jvm`              | Plugin     |         `1.9.0` |
| `kotlin-reflect`          | Dependency |         `1.9.0` |
| `JDA`                     | Dependency | `5.0.0-beta.12` |
| `JDA Kotlinx`             | Dependency |       `b101ea7` |